### PR TITLE
feat: handle `Ctrl+C` gracefully and display `Operation canceled`

### DIFF
--- a/lib/laws/cli.rb
+++ b/lib/laws/cli.rb
@@ -23,16 +23,21 @@ module Laws
   
         # Handle commands
         command = ARGV.join(' ')  # Join arguments to handle multi-word commands
-        case command
-        when 'ecs execute-command'
-          execute
-        when 'secretsmanager get-secret-value'
-          get_secret_value
-        when nil, ''
-          puts "No command specified. Use --help for usage information."
-          exit 1
-        else
-          puts "Unknown command: #{command}"
+        begin
+          case command
+          when 'ecs execute-command'
+            execute
+          when 'secretsmanager get-secret-value'
+            get_secret_value
+          when nil, ''
+            puts "No command specified. Use --help for usage information."
+            exit 1
+          else
+            puts "Unknown command: #{command}"
+            exit 1
+          end
+        rescue Interrupt, TTY::Reader::InputInterrupt
+          puts "\nOperation cancelled."
           exit 1
         end
       end
@@ -53,31 +58,31 @@ module Laws
           puts "No clusters found in the account."
           return
         end
-  
+
         selected_cluster = @prompt.select("Select a cluster:", clusters)
-  
+
         # List and select task
         tasks = @ecs_helper.list_tasks(selected_cluster)
         if tasks.empty?
           puts "No running tasks found in cluster #{selected_cluster}"
           return
         end
-  
+
         task_choices = @ecs_helper.create_task_choices(tasks)
         selected_task = @prompt.select("Select a task:", task_choices)
         task_id = selected_task.task_arn.split('/').last
-  
+
         # Select container if multiple containers exist
         container_names = @ecs_helper.get_container_names(selected_task)
         selected_container = if container_names.length > 1
-                             @prompt.select("Select a container:", container_names)
-                           else
-                             container_names.first
-                           end
-  
+                              @prompt.select("Select a container:", container_names)
+                            else
+                              container_names.first
+                            end
+
         # Get command from option or prompt
         command = @options[:command] || prompt_for_command
-  
+
         # Construct and execute the AWS CLI command
         aws_command = [
           "aws", "ecs", "execute-command",
@@ -87,14 +92,12 @@ module Laws
           "--interactive",
           "--command", command
         ].join(" ")
-  
+
         puts "\nExecuting command:"
         puts "#{aws_command}\n"
-  
+
         begin
           system(aws_command)
-        rescue Interrupt
-          puts "\nOperation cancelled by user"
         rescue StandardError => e
           puts "Error executing command: #{e.message}"
         end
@@ -106,10 +109,10 @@ module Laws
           puts "No secrets found in the account."
           return
         end
-  
+
         selected_secret = @prompt.select("Select a secret:", secrets)
         secret_value = @secrets_helper.get_secret_value(selected_secret)
-  
+
         puts "\nSecret value:"
         if secret_value.is_a?(Hash)
           secret_value.each { |key, value| puts "#{key}: #{value}" }


### PR DESCRIPTION
When a user presses `Ctrl+C` during a prompt, the CLI throws a `TTY::Reader::InputInterrupt` error and displays the entire call stack. This PR catches the error and displays a user-friendly message, "Operation canceled," instead of the full stack trace.